### PR TITLE
Feature support subdirectory

### DIFF
--- a/example/.gitignore
+++ b/example/.gitignore
@@ -1,0 +1,1 @@
+example

--- a/example/main.go
+++ b/example/main.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"fmt"
+	p "github.com/easykoo/echo-pongo2"
+	"github.com/labstack/echo"
+	mw "github.com/labstack/echo/middleware"
+	"net/http"
+)
+
+func main() {
+	e := echo.New()
+	e.Use(mw.Logger())
+	e.Use(mw.Recover())
+	fmt.Println("Prepare templates.")
+	t := p.PrepareTemplates(p.Options{
+		Directory:  "templates/",
+		Extensions: []string{".html"},
+	})
+	e.SetRenderer(t)
+
+	e.Get("/subdir1", func(c *echo.Context) error {
+		return c.Render(http.StatusOK, "index1", map[string]interface{}{"title": "index1", "msg": "index1"})
+	})
+	e.Get("/subdir2", func(c *echo.Context) error {
+		return c.Render(http.StatusOK, "index2", map[string]interface{}{"title": "index2", "msg": "index2"})
+	})
+	e.Get("/subdir3", func(c *echo.Context) error {
+		return c.Render(http.StatusOK, "index3", map[string]interface{}{"title": "index3", "msg": "index3"})
+	})
+
+	fmt.Println("Start server.")
+	e.Run(":8080")
+}

--- a/example/templates/index1.html
+++ b/example/templates/index1.html
@@ -1,0 +1,12 @@
+<!DOCCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{{ title }}</title>
+  </head>
+  <body>
+    <p>{{ msg }}</p>
+  </body>
+</html>
+

--- a/example/templates/subdir1/index2.html
+++ b/example/templates/subdir1/index2.html
@@ -1,0 +1,12 @@
+<!DOCCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{{ title }}</title>
+  </head>
+  <body>
+    <p>{{ msg }}</p>
+  </body>
+</html>
+

--- a/example/templates/subdir1/subdir2/index3.html
+++ b/example/templates/subdir1/subdir2/index3.html
@@ -1,0 +1,12 @@
+<!DOCCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{{ title }}</title>
+  </head>
+  <body>
+    <p>{{ msg }}</p>
+  </body>
+</html>
+

--- a/pongo2.go
+++ b/pongo2.go
@@ -5,7 +5,7 @@ import (
 	"io"
 	"io/ioutil"
 	"log"
-	"path"
+
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -45,45 +45,29 @@ func prepareOptions(opt Options) Options {
 
 func preCompile(opt Options) *Template {
 	tmplMap := make(map[string]*pongo2.Template)
-
-	dirPath := filepath.Dir(opt.Directory)
-	fileInfos, _ := ioutil.ReadDir(dirPath)
-
-	/*
-		for _, fileInfo := range fileInfos {
-			for _, s := range opt.Extensions {
-				if isMatched, _ := regexp.MatchString(".*"+s+"$", fileInfo.Name()); isMatched {
-					t, err := pongo2.FromFile(path.Join(opt.Directory, fileInfo.Name()))
-					if err != nil {
-						log.Fatalf("\"%s\": %v", fileInfo.Name(), err)
-					}
-					tmplMap[strings.Replace(fileInfo.Name(), s, "", -1)] = t
-				}
-			}
-		}
-	*/
 	readDirs(opt.Directory, opt.Extensions, tmplMap)
-
 	return &Template{tmplMap}
 }
 
 func readDirs(path string, ext []string, templates map[string]*pongo2.Template) *map[string]*pongo2.Template {
 	dirPath := filepath.Dir(path)
-	fileInfos, _ := ioutil.ReadDir(dirPath)
+	fileInfos, err := ioutil.ReadDir(dirPath)
+	if err != nil {
+		panic(err)
+	}
 
 	for _, fileInfo := range fileInfos {
 		// If fileInfo is directory, recurse the directory
 		if fileInfo.IsDir() {
-			readDirs(filepath.Join(dirPath, fileInfo.Name()), ext, templates)
-		} else {
-			for _, s := range ext {
-				if isMatched, _ := regexp.MatchString(".*"+s+"$", fileInfo.Name()); isMatched {
-					t, err := pongo2.FromFile(filepath.Join(path, fileInfo.Name()))
-					if err != nil {
-						log.Fatalf("\"%s\": %v", fileInfo.Name(), err)
-					}
-					templates[strings.Replace(fileInfo.Name(), s, "", -1)] = t
+			return readDirs(filepath.Join(dirPath, fileInfo.Name())+"/", ext, templates)
+		}
+		for _, s := range ext {
+			if isMatched, _ := regexp.MatchString(".*"+s+"$", fileInfo.Name()); isMatched {
+				t, err := pongo2.FromFile(filepath.Join(path, fileInfo.Name()))
+				if err != nil {
+					log.Fatalf("\"%s\": %v", fileInfo.Name(), err)
 				}
+				templates[strings.Replace(fileInfo.Name(), s, "", -1)] = t
 			}
 		}
 	}

--- a/pongo2.go
+++ b/pongo2.go
@@ -5,7 +5,6 @@ import (
 	"io"
 	"io/ioutil"
 	"log"
-
 	"path/filepath"
 	"regexp"
 	"strings"


### PR DESCRIPTION
Add function to recurse directory of templates and get template files from the sub directory of template directory like this.

```
example/
├── example
├── main.go
└── templates
    ├── index1.html
    └── subdir1
        ├── index2.html
        └── subdir2
            └── index3.html
```

And add an example.
